### PR TITLE
fix: bad display with resolutions other than 1920x1080

### DIFF
--- a/src/components/Tegami.tsx
+++ b/src/components/Tegami.tsx
@@ -29,6 +29,10 @@ export const Cover: FC<
       style={{
         backgroundImage: `url(/images/card.png)`,
         backgroundSize: "cover",
+        
+        // Magic number by measuring the actual element size of 1920x1080 screen
+        height: 760,
+        width: 982.3,
       }}
       className={clsx(
         "aspect-[517/400] h-full bg-right flex justify-end transiton-all",

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,7 @@ body,
 html {
   background: url("/images/background.jpg") no-repeat center center fixed;
   background-color: #cdd8e2;
+  background-size: cover;
 }
 
 @font-face {


### PR DESCRIPTION
On 2560x1440 for example, 

before:
![87d628896a397170a579876989cbe8a5](https://github.com/penguin-statistics/roguestats-frontend/assets/9929037/618627bd-fe72-4dde-a1b2-ea3a735baac4)

after:
![881c2b8791acf73db1e7aab5d8958a02](https://github.com/penguin-statistics/roguestats-frontend/assets/9929037/f7b5ac6d-d925-4399-896c-82e03ddbc225)
